### PR TITLE
Viewport

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ The behaviour for too long section or subsection lists is configurable. The font
 
 The background color of the footer is also configurable.
 
+For compatibility with Reveal.js 4.x, the viewport element to which
+`class` attributes are assigned from
+[`data-state`](https://revealjs.com/markup/#slide-states) is
+configurable.  With Reveal.js 3.x, this was the ```html``` element,
+while it is `body` with [Reveal.js 4.x](https://revealjs.com/markup/#viewport).
+
 # Installation
 
 ## Necessary files
@@ -55,10 +61,11 @@ Reveal.initialize
 
 ## Customization
 
-The ```toc_progress.initialize``` function can take two parameters:
+The ```toc_progress.initialize``` function can take three parameters:
 
 - ```reducescroll```: if ```'reduce'```, the font of the text of too long section or subsection lists is reduced to make the list fit in the footer; if ```'scroll'``` (default), the list will scroll when necessary.
 - ```background```: a string of the form ```'rgba(0,255,0,0.1)'```, for the background colour of the footer.
+- ```viewport```: a string such as ```'html'``` (default) or ```'body'``` to define the viewport for [slide states](https://revealjs.com/markup/#viewport).
 
 Including the ```toc_progress.create``` function in the Reveal.js initialization is not compulsory. If it is not included, the key ```q``` has to be pressed to create the footer.
 

--- a/plugin/toc-progress/toc-progress.js
+++ b/plugin/toc-progress/toc-progress.js
@@ -16,6 +16,7 @@ var toc_progress=
 	toc_progress_on:false,
 	reduceorscroll:'scroll',
 	background:'rgba(0,0,127,0.1)',
+	viewport:'html',
 };
 
 /* Function to obtain all child elements with any of the indicated tags (from http://www.quirksmode.org/dom/getElementsByTagNames.html) */
@@ -130,8 +131,8 @@ toc_progress.create=function()
 				a_element.appendChild(document.createTextNode(title_element.textContent));
 				li_element.appendChild(a_element);
 				style_node.textContent=style_node.textContent+'.toc-progress-'+main_sections_index.toString()+' #toc-progress-'+main_sections_index.toString()+' {font-weight: bold;}\n';
-				style_node.textContent=style_node.textContent+'html[class*="toc-progress-'+main_sections_index.toString()+'-"] #toc-progress-'+main_sections_index.toString()+' {font-weight: bold;}\n';
-				style_node.textContent=style_node.textContent+'html:not([class*="toc-progress-'+main_sections_index.toString()+'-"]):not([class*="toc-progress-'+main_sections_index.toString()+' "]):not([class$="toc-progress-'+main_sections_index.toString()+'"]) li[id^="toc-progress-'+main_sections_index.toString()+'-"] {display: none;}\n';
+				style_node.textContent=style_node.textContent+this.viewport+'[class*="toc-progress-'+main_sections_index.toString()+'-"] #toc-progress-'+main_sections_index.toString()+' {font-weight: bold;}\n';
+				style_node.textContent=style_node.textContent+this.viewport+':not([class*="toc-progress-'+main_sections_index.toString()+'-"]):not([class*="toc-progress-'+main_sections_index.toString()+' "]):not([class$="toc-progress-'+main_sections_index.toString()+'"]) li[id^="toc-progress-'+main_sections_index.toString()+'-"] {display: none;}\n';
 				main_title_set = true;
 			}
 			else if (title_element==null)
@@ -186,8 +187,8 @@ toc_progress.create=function()
 						a_element.appendChild(document.createTextNode(title_element.textContent));
 						li_element.appendChild(a_element);
 						style_node.textContent=style_node.textContent+'.toc-progress-'+main_sections_index.toString()+' #toc-progress-'+main_sections_index.toString()+' {font-weight: bold;}\n';
-						style_node.textContent=style_node.textContent+'html[class*="toc-progress-'+main_sections_index.toString()+'-"] #toc-progress-'+main_sections_index.toString()+' {font-weight: bold;}\n';
-						style_node.textContent=style_node.textContent+'html:not([class*="toc-progress-'+main_sections_index.toString()+'-"]):not([class*="toc-progress-'+main_sections_index.toString()+' "]):not([class$="toc-progress-'+main_sections_index.toString()+'"]) li[id^="toc-progress-'+main_sections_index.toString()+'-"] {display: none;}\n';
+						style_node.textContent=style_node.textContent+this.viewport+'[class*="toc-progress-'+main_sections_index.toString()+'-"] #toc-progress-'+main_sections_index.toString()+' {font-weight: bold;}\n';
+						style_node.textContent=style_node.textContent+this.viewport+':not([class*="toc-progress-'+main_sections_index.toString()+'-"]):not([class*="toc-progress-'+main_sections_index.toString()+' "]):not([class$="toc-progress-'+main_sections_index.toString()+'"]) li[id^="toc-progress-'+main_sections_index.toString()+'-"] {display: none;}\n';
 					}
 					else if (secondary_sections_index!=0)
 					{
@@ -358,7 +359,7 @@ toc_progress.reduceorscrollelementifnecessary=function(element)
 
 /* Method to initialize the TOC-Progress footer */
 
-toc_progress.initialize=function(reducescroll,background)
+toc_progress.initialize=function(reducescroll,background,viewport)
 {
 
 	// Try to determine path to CSS by replacing "js" with "css".
@@ -385,6 +386,7 @@ toc_progress.initialize=function(reducescroll,background)
 
 	this.reduceorscroll=reducescroll || 'scroll';
 	this.background=background || 'rgba(0,0,127,0.1)';
+	this.viewport=viewport || 'html';
 
 	// Capture 'q' key to toggle the display of the TOC-Progress footer
 	mappings = Reveal.getConfig().keyboard;


### PR DESCRIPTION
The secondary footer remains invisible with Reveal.js 4 as the `data-state` is now applied to the `body` element, not `html`. See there:
- https://revealjs.com/markup/#slide-states
- https://revealjs.com/markup/#viewport

This PR allows to configure this.